### PR TITLE
Python 3.8 compatability + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Extension for FastAPI to make HTMX easier to use.
 FastAPI-HTMX is an opinionated extension for FastAPI to speed up development of lightly interactive web applications. FastAPI-HTMX is implemented as a decorator, so it can be used on endpoints selectively. Furthermore it reduces boilerplate for Jinja2 template handling and allows for rapid prototyping by providing convenient helpers.
 
 [![Tests](https://github.com/maces/fastapi-htmx/actions/workflows/github-actions-tests.yml/badge.svg)](https://github.com/maces/fastapi-htmx/actions/workflows/github-actions-tests.yml)
+[![Version](https://img.shields.io/pypi/v/fastapi-htmx?logo=pypi&logoColor=white)](https://pypi.org/project/fastapi-htmx/)
+
 
 ## Install
 
@@ -105,9 +107,9 @@ The idea behind FastAPI-HTMX is to maintain a modular structure in the app and w
 - A simple endpoint just answers with the partial.
 - Without it, if the URL is rewritten and a user navigates back, reloads the page or copies the URL and opens it in another tab or shares the URL, only the partial would be shown in the browser.
 
-**To enable SPA like functionality FastAPI-HTMX uses the concept of partials and fullpages as arguments for the decorator and requires to return a dict of the needed variables**.
+**To enable SPA like functionality FastAPI-HTMX uses the concept of partials and fullpages as arguments for the decorator and requires to return a dict of the needed variables**. Note that returning anything else than a `Mapping` like a dict in the route, leads FastAPI-HTMX to return that instead of a template.
 
-In order to support this in an app, see the following example:
+In order to support this SPA like functionality in an app, see the following example:
 
 `my_app/api_with_constructors.py`:
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-htmx"
-version = "0.2.3"
+version = "0.3.0"
 description = "Extension for FastAPI to make HTMX easier to use."
 authors = ["maces <fastapi-htmx@mzip.de>"]
 license = "LGPL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
     "Environment :: Web Environment",
@@ -37,7 +39,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 fastapi = ">=0.94,^0.104"
 jinja2 = "^3.1"
 
@@ -56,14 +58,14 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 120
-target-version = ['py310']
+target-version = ['py38']
 
 [tool.isort]
 profile = "black"
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py38"
 select = [
     # Pyflakes
     "F",

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,25 @@
+import pytest
+
+from fastapi_htmx.htmx import _is_fullpage_request
+
+
+class MockRequest:  # noqa: D101
+    def __init__(self, headers: dict):  # noqa: D107
+        self.headers = headers
+
+
+@pytest.mark.parametrize(
+    "headers,result",
+    [
+        ({"HX-Request": "true"}, False),
+        ({"HX-Request": "TRUE"}, False),
+        ({"HX-Request": "True"}, False),
+        ({"HX-Request": "false"}, True),
+        ({"HX-Request-Not": "true"}, True),
+        ({}, True),
+    ],
+)
+def test_is_fullpage_request(headers: dict, result: bool):
+    request = MockRequest(headers=headers)
+
+    assert _is_fullpage_request(request) == result  # Type: ignore

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -22,4 +22,4 @@ class MockRequest:  # noqa: D101
 def test_is_fullpage_request(headers: dict, result: bool):
     request = MockRequest(headers=headers)
 
-    assert _is_fullpage_request(request) == result  # Type: ignore
+    assert _is_fullpage_request(request) == result  # type: ignore

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -2,6 +2,7 @@ import re
 import shutil
 import textwrap
 from pathlib import Path
+from typing import Dict
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,9 +10,9 @@ from fastapi.testclient import TestClient
 file_name_in_markdown_pattern = re.compile("`([a-zA-Z0-9/_.]*)`")
 
 
-def extract_test_cases_from_readme() -> dict[str, dict[str, str]]:
+def extract_test_cases_from_readme() -> Dict[str, Dict[str, str]]:
     print(Path(".").absolute())
-    test_cases: dict[str, dict[str, str]] = {}
+    test_cases: Dict[str, Dict[str, str]] = {}
     with open(Path("README.md")) as readme_file:
         readme = textwrap.dedent(readme_file.read())
         file_name = ""
@@ -47,7 +48,7 @@ def extract_test_cases_from_readme() -> dict[str, dict[str, str]]:
     return test_cases
 
 
-def create_test_files(test_case: dict[str, str]):
+def create_test_files(test_case: Dict[str, str]):
     shutil.rmtree("my_app", ignore_errors=True)  # cleanup
     for file_path, file_content in test_case.items():
         Path(file_path).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
- Made Extension Python 3.8 compatible
- Clarifies return behaviour
- simplified fullpage detection and added tests for that
- Fixed some typos and error in docs
