### PR TITLE
Switch from an Exception with a 500er status code to a 400er status code

### DIFF
--- a/fastapi_htmx/htmx.py
+++ b/fastapi_htmx/htmx.py
@@ -5,16 +5,20 @@ from collections.abc import Callable, Mapping
 from functools import wraps
 from typing import Optional
 
-from fastapi import Request
+from fastapi import Request, HTTPException
 from fastapi.templating import Jinja2Templates
 
 templates_path: Optional[Jinja2Templates] = None
 
 
-class MissingFullPageTemplateError(Exception):
+class MissingFullPageTemplateError(HTTPException):
     """Fullpage request not a corresponding template configured for url rewriting and history to work."""
 
-    pass
+    def __init__(self) -> None:  # noqa: D107
+        super().__init__(status_code=400, detail="Ressource cannot be accessed directly.")
+        logging.debug(
+            "Route is not configured to be queried directly. Please specify a fullpage template + data for that."
+        )
 
 
 class MissingHTMXInitError(Exception):

--- a/fastapi_htmx/htmx.py
+++ b/fastapi_htmx/htmx.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping
 from functools import wraps
 from typing import Optional
 
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
 from fastapi.templating import Jinja2Templates
 
 templates_path: Optional[Jinja2Templates] = None

--- a/tests/test_raising.py
+++ b/tests/test_raising.py
@@ -39,8 +39,8 @@ def test_missing_fullpage_template():
 
     client = TestClient(app)
 
-    with pytest.raises(MissingFullPageTemplateError):
-        client.get("/")
+    response = client.get("/")
+    assert response.status_code == 400
 
 
 def test_missing_init():

--- a/tests/test_raising.py
+++ b/tests/test_raising.py
@@ -8,7 +8,7 @@ from fastapi.templating import Jinja2Templates
 from fastapi.testclient import TestClient
 
 from fastapi_htmx import htmx, htmx_init
-from fastapi_htmx.htmx import MissingFullPageTemplateError, MissingHTMXInitError
+from fastapi_htmx.htmx import MissingHTMXInitError
 
 
 def test_missing_request():


### PR DESCRIPTION
See #9 for the motivation.

This returns a 400er status code instead of a 500er caused by an exception. The idea being to not confuse observability systems when such a request was made.