### PR TITLE
bump v0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-htmx"
-version = "0.3.0"
+version = "0.3.1"
 description = "Extension for FastAPI to make HTMX easier to use."
 authors = ["maces <fastapi-htmx@mzip.de>"]
 license = "LGPL"


### PR DESCRIPTION
Switched HTTP Status Code for MissingFullPageTemplateError to a 400 and updated dependencies