### PR TITLE
Add support for multiple template collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ htmx_init(templates=templates)
 
 #### Multiple Template Directories
 
-For bigger apps, multiple template directories might be needed. For example if the app split into several modules each for a distinct part of the app and connected with routers. For this case template collections can be used. During `htmx_init()` multiple template collections can be defined. In each endpoint instead of the templates name (`account`) the collection gets specified as well, like this: `Tpl(SHOP, "account")`. This works for partials and full pages.
+For bigger apps, multiple template directories might be needed. For example if the app is split into several modules connected with routers. For this case template collections can be used. With `htmx_init()` multiple template collections can be defined. In each endpoint instead of the templates name (`account`) the collection gets specified as well, like this: `Tpl(SHOP, "account")`. This works for partials and full pages.
 
 `my_app/api_multiple_template_paths.py`:
 ```python

--- a/README.md
+++ b/README.md
@@ -203,30 +203,75 @@ To add additional partials and endpoints just repeat the same logic:
 
 ### Advanced Usage
 
+
+#### Handling `HX-Request` manually
+
 In case the `htmx()` arguments for partial and fullpage callables are not flexible enough, an endpoint can be used like usual. For a bit more convenience the `HX-Request` header is easily accessible via `request.hx_request`:
 
+`my_app/api_with_hx_request.py`:
 ```python
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 from fastapi_htmx import HXRequest, htmx, htmx_init
 
+app = FastAPI()
+htmx_init(templates=Jinja2Templates(directory=Path("my_app") / "templates"))
+
+def my_partial(email_id: int = None):
+    return {"email_id": email_id}
+
+def fullpage(email_id: int = None):
+    return {**my_partial(email_id)}
+
+@app.get("/email/{email_id}", response_class=HTMLResponse)
 @htmx("email_detail", "index")
 def get_email(request: HXRequest, email_id: int):
     if request.hx_request:
-        return my_partial()
+        return my_partial(email_id)
     else:
-        return fullpage()
+        return fullpage(email_id)
 ```
+
+`my_app/templates/index.jinja2`:
+```jinja2
+<!DOCTYPE html>
+<html><head><title>Hello FastAPI-HTMX</title></head>
+<body>
+    <div id="email_detail">
+        {% include 'email_detail.jinja2' %}
+    </div>
+    <script src="https://unpkg.com/htmx.org@1.9.6"></script>
+</body>
+</html>
+```
+
+`my_app/templates/email_detail.jinja2`:
+```jinja2
+<p>{{ email_id }}</p>
+```
+
 
 #### Filters
 
 In order to use [custom Jinja2 filters](https://jinja.palletsprojects.com/en/3.1.x/api/#custom-filters) like the following, configure them like below.
 
+`my_app/templates/customer.jinja2`:
 ```Jinja2
 <p>{{ customer.created|datetime_format }}</p>
 ```
 
 Add custom filters for use in Jinja2 templates:
+`my_app/api_template_filters.py`:
 ```python
-# ...
+from pathlib import Path
+from datetime import datetime
+
+from fastapi.templating import Jinja2Templates
+from fastapi_htmx import htmx_init
+
 def datetime_format(value: datetime, format="%H:%M %d.%m.%Y"):
     return value.strftime(format) if value is not None else ""
 
@@ -234,4 +279,108 @@ templates = Jinja2Templates(directory=Path("my_app") / "templates")
 templates.env.filters["datetime_format"] = datetime_format
 htmx_init(templates=templates)
 # ...
+```
+
+
+#### Multiple Template Directories
+
+For bigger apps, multiple template directories might be needed. For example if the app split into several modules each for a distinct part of the app and connected with routers. For this case template collections can be used. During `htmx_init()` multiple template collections can be defined. In each endpoint instead of the templates name (`account`) the collection gets specified as well, like this: `Tpl(SHOP, "account")`. This works for partials and full pages.
+
+`my_app/api_multiple_template_paths.py`:
+```python
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi_htmx import htmx, htmx_init, TemplateSpec as Tpl
+
+SHOP = "shop"
+BACKEND = "backend"
+
+app = FastAPI()
+templates = {
+    SHOP: Jinja2Templates(directory=Path("my_app") / SHOP / "templates"),
+    BACKEND: Jinja2Templates(directory=Path("my_app") / BACKEND / "templates")
+}
+htmx_init(templates=templates)
+
+@app.get("/account", response_class=HTMLResponse)
+@htmx(Tpl(SHOP, "account"))
+async def get_account(request: Request):
+    pass
+
+@app.get("/products", response_class=HTMLResponse)
+@htmx(Tpl(BACKEND, "products"))
+async def get_products(request: Request):
+    pass
+
+```
+
+`my_app/shop/templates/account.jinja2`:
+```jinja2
+<h1>My Account</h1>
+```
+
+`my_app/backend/templates/products.jinja2`:
+```jinja2
+<h1>Products</h1>
+```
+
+
+#### Other template file extensions for SOME endpoints
+
+In case SOME endpoints templates got another file extension than the rest, it can be specified in the `@htmx()` decorator:
+
+`my_app/api_template_file_extension.py`:
+```python
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi_htmx import htmx, htmx_init
+
+app = FastAPI()
+htmx_init(templates=Jinja2Templates(directory=Path("my_app") / "templates"))
+
+@app.get("/customers", response_class=HTMLResponse)
+@htmx("customers", template_extension="html")
+async def get_customers(request: Request):
+    pass
+# ...
+```
+
+`my_app/templates/customers.html`:
+```jinja2
+<h1>Customer</h1>
+```
+
+
+#### Other template file extensions for ALL endpoints
+
+In case ALL endpoints templates got another file extension than the default `jinja2`, it can be overriden in `htmx_init()` like this:
+
+`my_app/api_template_file_extension.py`:
+```python
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi_htmx import htmx, htmx_init
+
+app = FastAPI()
+templates = Jinja2Templates(directory=Path("my_app") / "templates")
+htmx_init(templates=templates, file_extension="html")
+
+@app.get("/customers", response_class=HTMLResponse)
+@htmx("customers")
+async def get_customers(request: Request):
+    pass
+```
+
+`my_app/templates/customers.html`:
+```jinja2
+<h1>Customer</h1>
 ```

--- a/fastapi_htmx/__init__.py
+++ b/fastapi_htmx/__init__.py
@@ -1,5 +1,6 @@
 """Extension for FastAPI to make HTMX easier to use."""
 
 from .htmx import HXRequest as HXRequest
+from .htmx import TemplateSpec as TemplateSpec
 from .htmx import htmx as htmx
 from .htmx import htmx_init as htmx_init

--- a/fastapi_htmx/htmx.py
+++ b/fastapi_htmx/htmx.py
@@ -61,8 +61,8 @@ class HXRequest(Request):
     hx_request: bool = False
 
 
-def _get_template_name(name: str, file_extension: str) -> TemplateFileInfo:
-    if isinstance(name, TemplateSpec):
+def _get_template_name(name: Union[TemplateSpec, str], file_extension: Optional[str]) -> TemplateFileInfo:
+    if isinstance(name, TemplateSpec) and isinstance(templates_path, dict):
         try:
             templates_collection_path = templates_path[name.collection_name]
             template_name_in_collection = name.template_name
@@ -72,8 +72,8 @@ def _get_template_name(name: str, file_extension: str) -> TemplateFileInfo:
                 "Please specify all collections of templates used in the decorators"
             )
     else:
-        templates_collection_path = templates_path
-        template_name_in_collection = name
+        templates_collection_path = templates_path  # type: ignore
+        template_name_in_collection = name  # type: ignore
 
     if file_extension is None:
         file_extension = templates_file_extension

--- a/fastapi_htmx/htmx.py
+++ b/fastapi_htmx/htmx.py
@@ -2,13 +2,35 @@
 import inspect
 import logging
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from functools import wraps
-from typing import Optional
+from typing import Dict, Optional, Union
 
 from fastapi import HTTPException, Request
 from fastapi.templating import Jinja2Templates
 
-templates_path: Optional[Jinja2Templates] = None
+TemplatePath = Union[Jinja2Templates, Dict[str, Jinja2Templates]]
+TemplateName = str
+templates_path: Optional[TemplatePath] = None
+templates_file_extension: Optional[str] = None
+
+
+@dataclass
+class TemplateFileInfo:
+    """A template collection and template name ready for use."""
+
+    __slots__ = ("collection", "file_name")
+    collection: Jinja2Templates
+    file_name: TemplateName
+
+
+@dataclass
+class TemplateSpec:
+    """A template specification in case multiple collections are used."""
+
+    __slots__ = ("collection_name", "template_name")
+    collection_name: str
+    template_name: TemplateName
 
 
 class MissingFullPageTemplateError(HTTPException):
@@ -27,29 +49,58 @@ class MissingHTMXInitError(Exception):
     pass
 
 
+class InvalidHTMXInitError(Exception):
+    """FastAPI-HTMX was not initialized properly."""
+
+    pass
+
+
 class HXRequest(Request):
     """FastAPI Request Object with HTMX additions."""
 
     hx_request: bool = False
 
 
+def _get_template_name(name: str, file_extension: str) -> TemplateFileInfo:
+    if isinstance(name, TemplateSpec):
+        try:
+            templates_collection_path = templates_path[name.collection_name]
+            template_name_in_collection = name.template_name
+        except KeyError:
+            raise InvalidHTMXInitError(
+                "FASTAPI-HTMX was not initialized properly."
+                "Please specify all collections of templates used in the decorators"
+            )
+    else:
+        templates_collection_path = templates_path
+        template_name_in_collection = name
+
+    if file_extension is None:
+        file_extension = templates_file_extension
+
+    template_file_name_in_collection = f"{template_name_in_collection}.{file_extension}"
+
+    return TemplateFileInfo(collection=templates_collection_path, file_name=template_file_name_in_collection)
+
+
 def htmx(  # noqa: C901
-    partial_template_name: str,
-    full_template_name: Optional[str] = None,
+    partial_template_name: Union[TemplateSpec, TemplateName],
+    full_template_name: Optional[Union[TemplateSpec, TemplateName]] = None,
     partial_template_constructor: Optional[Callable] = None,
     full_template_constructor: Optional[Callable] = None,
-    template_extension: str = "jinja2",
+    template_extension: Optional[str] = None,
 ) -> Callable:
     """Decorator for FastAPI routes to make HTMX easier to use.
 
     Args:
-        partial_template_name (str): A Template for the partial to use.
-        full_template_name (Optional[str], optional): The full page template name. Defaults to None.
-        partial_template_constructor (Optional[Callable], optional): A Callable returning the needed variables for the
-                                                                  template. Defaults to None.
-        full_template_constructor (Optional[Callable], optional): A Callable returning the needed variables for the
-                                                               template. Defaults to None.
-        template_extension (str, optional): The template extension to use. Defaults to "jinja2".
+        partial_template_name (Union[TemplateSpec, TemplateName]): A Template for the partial to use.
+        full_template_name (Optional[Union[TemplateSpec, TemplateName]]): The full page template name.
+                                                                                        Defaults to None.
+        partial_template_constructor (Optional[Callable]): A Callable returning the needed variables for the template.
+                                                           Defaults to None.
+        full_template_constructor (Optional[Callable]): A Callable returning the needed variables for the template.
+                                                        Defaults to None.
+        template_extension (Optional[str]): The template extension to use. Defaults to None.
 
     Raises:
         MissingFullPageTemplateError: If a full page is required bu no template is specified.
@@ -105,8 +156,9 @@ def htmx(  # noqa: C901
                     "before using the '@htmx(...)' decorator"
                 )
 
-            return templates_path.TemplateResponse(
-                f"{template_name}.{template_extension}",
+            template = _get_template_name(name=template_name, file_extension=template_extension)
+            return template.collection.TemplateResponse(
+                template.file_name,
                 {
                     "request": request,
                     **response,
@@ -122,11 +174,15 @@ def _is_fullpage_request(request: Request) -> bool:
     return "HX-Request" not in request.headers or request.headers["HX-Request"].lower() != "true"
 
 
-def htmx_init(templates: Jinja2Templates):
+def htmx_init(templates: TemplatePath, file_extension: str = "jinja2"):
     """Initialize the HTMX extension.
 
     Args:
-        templates (Jinja2Templates): The configured template instance to use.
+        templates (TemplatePath): The configured template instance to use.
+                                  Or multiple template collections distinguished by a key.
+        file_extension: (str): The file extension to use for all templates. Can be individually overriden.
     """
     global templates_path
     templates_path = templates
+    global templates_file_extension
+    templates_file_extension = file_extension


### PR DESCRIPTION
Based on Issue #11 this PR adds support for multiple template directories in the same app. The whole solutions is optional but when used needs to be used in every endpoint. Additionally the templates file extension can now be overridden globally.